### PR TITLE
Fix naming bug in code sample

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -123,7 +123,7 @@ partial interface MediaStreamTrack {
        // The platform supports background blurring and
        // allows it to be enabled.
        // Let's try use platform background blurring.
-       await track.applyConstraints({backgroundBlur: true});
+       await videoTrack.applyConstraints({backgroundBlur: true});
      }
      const videoSettings = videoTrack.getSettings();
      if (videoSettings.backgroundBlur) {


### PR DESCRIPTION
I tried to put this code in action and noted a small typo. 

That being said, the [demo](https://background-blur-api.glitch.me/) fails with `Uncaught (in promise) DOMException: Failed to execute 'postMessage' on 'Worker': Value at index 0 does not have a transferable type.`. I have set the origin trial token and try in Canary. 

<img width="684" alt="Screenshot 2023-03-30 at 11 00 20" src="https://user-images.githubusercontent.com/145676/228801515-83603d1a-5aaa-40d0-b283-2a81a0de4b69.png">
 